### PR TITLE
fix: update registry timestamp command to use proper date format

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -113,7 +113,8 @@ jobs:
       
       - name: Update registry timestamp
         run: |
-          jq '.updated = now | strftime("%Y-%m-%dT%H:%M:%SZ")' servers/registry.json > servers/registry.json.tmp
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          jq --arg ts "$TIMESTAMP" '.updated = $ts' servers/registry.json > servers/registry.json.tmp
           mv servers/registry.json.tmp servers/registry.json
           
       - name: Commit registry update


### PR DESCRIPTION
## Summary
- Replace jq's non-existent 'now' function with shell date command
- Use jq's --arg option to pass timestamp as a variable
- Fixes 'strftime/1 requires parsed datetime inputs' error

## Details
The previous implementation tried to use `jq`'s `now` function which doesn't exist. This PR updates the command to:
1. Generate the timestamp using the shell's `date` command
2. Pass it to `jq` using the `--arg` parameter
3. Set the `.updated` field to this timestamp value

## Test Plan
- [x] Verified the new command works locally
- [ ] GitHub Actions workflow will validate on merge

Fixes the error:
```
jq: error (at servers/registry.json:44): strftime/1 requires parsed datetime inputs
Error: Process completed with exit code 5
```