### PR TITLE
Fix registry attestation error by adding missing Docker build step ID

### DIFF
--- a/.github/workflows/build-registry.yml
+++ b/.github/workflows/build-registry.yml
@@ -53,6 +53,7 @@ jobs:
           echo "Registry version: $VERSION"
           
       - name: Build and push registry image
+        id: push
         uses: docker/build-push-action@v6
         with:
           context: servers


### PR DESCRIPTION
## Summary
- Fixed attestation error in registry build workflow by adding missing `id` attribute to Docker build step
- The attestation step was failing because it couldn't find the digest output from the push step

## Test plan
- [x] Verified the workflow syntax is correct
- [x] Confirmed only one attestation usage in the codebase
- [ ] The fix will be validated when the workflow runs on merge to main

🤖 Generated with [Claude Code](https://claude.ai/code)