### PR TITLE
fix: add actions write permission to sync-mcp-repos workflow

### DIFF
--- a/.github/workflows/sync-mcp-repos.yml
+++ b/.github/workflows/sync-mcp-repos.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
Fixes the sync-mcp-repos workflow that was failing with "Resource not accessible by integration" error.

## Problem
The workflow was trying to trigger build-servers.yml after syncing commits but didn't have the necessary permissions.

## Solution
Added `actions: write` permission to allow the workflow to trigger other workflows.

## Test Plan
- [ ] Verify workflow runs successfully
- [ ] Confirm it can trigger build-servers workflow when commits change
- [ ] Check that the sync still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)