### PR TITLE
fix: add Docker login for all builds to resolve 401 errors

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git reset:*)",
+      "Bash(gh run view:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)"
+    ],
+    "deny": []
+  }
+}

--- a/.github/workflows/build-servers.yml
+++ b/.github/workflows/build-servers.yml
@@ -186,7 +186,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         
       - name: Log in to GitHub Container Registry
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
## Summary
- Remove conditional Docker login that only ran on main branch pushes
- All builds need authentication to pull base images from ghcr.io
- Fixes 401 Unauthorized errors when pulling base images in PR builds

## Context
The build-servers workflow was failing with 401 Unauthorized errors when trying to pull base images. This was because the Docker login step was conditional and only ran for main branch pushes, but PR builds also need to authenticate to pull our private base images.

## Test plan
- [ ] PR builds should now be able to pull base images without authentication errors
- [ ] Main branch builds should continue to work as before
- [ ] Manual workflow dispatch should also authenticate properly

Fixes errors from: https://github.com/stigenai/mcp-servers/actions/runs/16162701473/job/45617380385

🤖 Generated with [Claude Code](https://claude.ai/code)