### PR TITLE
feat: add push option to manual workflow and default to all servers

### DIFF
--- a/.github/workflows/build-servers.yml
+++ b/.github/workflows/build-servers.yml
@@ -6,7 +6,7 @@ on:
       servers:
         description: 'Servers to build (comma-separated, e.g. "time,playwright" or "all")'
         required: false
-        default: ''
+        default: 'all'
         type: string
       force_build:
         description: 'Force rebuild even if no changes detected'
@@ -15,6 +15,11 @@ on:
         type: boolean
       build_base:
         description: 'Also rebuild base images'
+        required: false
+        default: false
+        type: boolean
+      push_images:
+        description: 'Push built images to registry'
         required: false
         default: false
         type: boolean
@@ -151,7 +156,7 @@ jobs:
     if: needs.detect-changes.outputs.base-changed == 'true' || (github.event_name == 'workflow_dispatch' && inputs.build_base == true)
     uses: ./.github/workflows/build-base-images.yml
     with:
-      push_images: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      push_images: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.push_images) }}
       image_tag_suffix: ${{ github.event_name == 'pull_request' && format('-pr-{0}', github.event.pull_request.number) || '' }}
     permissions:
       contents: read
@@ -252,10 +257,10 @@ jobs:
             mcp.server=${{ matrix.server }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          push: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.push_images) }}
       
       - name: Run Trivy vulnerability scanner
-        if: steps.check-rebuild.outputs.skip != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: steps.check-rebuild.outputs.skip != 'true' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.push_images))
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}${{ matrix.server }}:latest
@@ -266,7 +271,7 @@ jobs:
           ignore-unfixed: true
       
       - name: Upload Trivy scan results
-        if: steps.check-rebuild.outputs.skip != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: steps.check-rebuild.outputs.skip != 'true' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.push_images))
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary
- Add `push_images` input to workflow_dispatch for manual image pushes
- Change default servers from empty to 'all' for easier manual runs
- Update push conditions throughout the workflow to respect manual input

## Changes
1. **New workflow input**: `push_images` (boolean, default: false)
   - Allows manual workflow runs to push images to the registry
   - Useful for testing or emergency deployments

2. **Default servers**: Changed from empty string to 'all'
   - Makes manual runs more convenient - no need to type 'all' every time
   - Users can still override with specific server names

3. **Updated push logic**: 
   - Docker push now respects the manual `push_images` input
   - Trivy scans also run when manually pushing
   - Base image builds also respect the push option

## Test plan
- [ ] Manual workflow dispatch with push_images=false builds but doesn't push
- [ ] Manual workflow dispatch with push_images=true builds and pushes
- [ ] Default behavior (all servers) works correctly
- [ ] Specifying individual servers still works
- [ ] Automatic builds on main branch continue to work

🤖 Generated with [Claude Code](https://claude.ai/code)