### PR TITLE
fix: resolve workflow startup failure in build-servers

### DIFF
--- a/.github/workflows/build-servers.yml
+++ b/.github/workflows/build-servers.yml
@@ -135,13 +135,17 @@ jobs:
                 done
               fi
               
-              # Check for direct file changes dynamically for each server
+              # Check for direct file changes
+              # Get all changed files as JSON array
+              CHANGED_FILES='${{ steps.changed-files.outputs.all_changed_files }}'
+              
+              # Check each server directory for changes
               for server in $(echo $ALL_SERVERS | jq -r '.[]'); do
-                # Get the output variable name for this server
-                VAR_NAME="${server}_any_changed"
-                VAR_VALUE=$(eval echo \${{ steps.changed-files.outputs.${VAR_NAME} }})
+                # Get the server type from registry
+                SERVER_TYPE=$(jq -r ".servers.$server.type" servers/registry.json)
                 
-                if [ "$VAR_VALUE" == "true" ]; then
+                # Check if any changed files are in this server's directory
+                if echo "$CHANGED_FILES" | jq -r '.[]' | grep -q "^servers/$SERVER_TYPE/$server/"; then
                   echo "Files changed for $server"
                   SERVERS=$(echo $SERVERS | jq --arg server "$server" '. += [$server]')
                 fi


### PR DESCRIPTION
## Summary
Fixes the workflow startup failure introduced in PR #18 by removing problematic dynamic variable interpolation.

## Problem
The build-servers workflow was failing with a startup error due to invalid GitHub expression syntax when trying to dynamically reference step outputs.

## Solution
- Remove the problematic eval-based dynamic variable interpolation
- Use the `all_changed_files` output which provides a JSON array of all changed files
- Check if any changed files match each server's directory pattern

## Test plan
- [ ] Workflow parses correctly without startup errors
- [ ] Change detection still works for individual servers
- [ ] Registry changes still trigger appropriate rebuilds